### PR TITLE
Add alias to authorize my IP for SSH access to a security group

### DIFF
--- a/alias
+++ b/alias
@@ -48,3 +48,9 @@ authorize-my-ip =
     ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
     aws ec2 authorize-security-group-ingress --group-id ${1} --cidr $ip/32 --protocol tcp --port 22
   }; f
+
+get-group-id = 
+  !f() {
+    aws ec2 describe-security-groups --filters Name=group-name,Values=${1} --query SecurityGroups[0].GroupId --output text
+  }; f
+

--- a/alias
+++ b/alias
@@ -54,3 +54,8 @@ get-group-id =
     aws ec2 describe-security-groups --filters Name=group-name,Values=${1} --query SecurityGroups[0].GroupId --output text
   }; f
 
+authorize-my-ip-by-name =
+  !f() {
+    group_id=$(aws get-group-id "${1}")
+    aws authorize-my-ip "$group_id"
+  }; f

--- a/alias
+++ b/alias
@@ -42,3 +42,9 @@ list-sgs = ec2 describe-security-groups --query "SecurityGroups[].[GroupId, Grou
 sg-rules = !f() { aws ec2 describe-security-groups \
     --query "SecurityGroups[].IpPermissions[].[FromPort,ToPort,IpProtocol,join(',',IpRanges[].CidrIp)]" \
     --group-id "$1" --output text; }; f
+
+authorize-my-ip =
+  !f() {
+    ip=$(dig +short myip.opendns.com @resolver1.opendns.com)
+    aws ec2 authorize-security-group-ingress --group-id ${1} --cidr $ip/32 --protocol tcp --port 22
+  }; f


### PR DESCRIPTION
I should note that this only works on MacOS and linux systems with `dig` installed. I know that this won't work out of the box on windows, and I'm not sure if there are linux distributions that don't come with dig. 

This is one of the aliases from the reinvent presentation on the AWS CLI, so maybe Kyle Knapp, the presenter, can provide some insight. 