### PR TITLE
list all security group port ranges open to 0.0.0.0/0

### DIFF
--- a/alias
+++ b/alias
@@ -42,3 +42,15 @@ list-sgs = ec2 describe-security-groups --query "SecurityGroups[].[GroupId, Grou
 sg-rules = !f() { aws ec2 describe-security-groups \
     --query "SecurityGroups[].IpPermissions[].[FromPort,ToPort,IpProtocol,join(',',IpRanges[].CidrIp)]" \
     --group-id "$1" --output text; }; f
+
+# list all security group port ranges open to 0.0.0.0/0
+public-ports = ec2 describe-security-groups \
+  --filters Name=ip-permission.cidr,Values=0.0.0.0/0 \
+  --query 'SecurityGroups[].{
+    GroupName:GroupName,
+    GroupId:GroupId,
+    PortRanges:
+      IpPermissions[?contains(IpRanges[].CidrIp, `0.0.0.0/0`)].[
+        join(`:`, [IpProtocol, join(`-`, [to_string(FromPort), to_string(ToPort)])])
+      ][]
+  }'


### PR DESCRIPTION
This outputs a list of all port ranges open to 0.0.0.0/0.

Example:
```
$ aws public-ports

[
    {
        "GroupName": "public-elb",
        "GroupId": "sg-xxxxxxxx",
        "PortRanges": [
            "tcp:80-80",
            "tcp:443-443"
        ]
    },
    {
        "GroupName": "bastion",
        "GroupId": "sg-xxxxxxxx",
        "PortRanges": [
            "tcp:22-22"
        ]
    }
]
```