### PR TITLE
added get-codebuild-build-log to help with debugging failing codebuil…

### DIFF
--- a/alias
+++ b/alias
@@ -135,7 +135,20 @@ revoke-my-ip-all =
     aws revoke-my-ip ${1} all all
   }; f
 
-get-codebuild-build-log =
+codebuild-get-latest-id =
+  !f() {
+    if [ "${1}" == "" ]; then
+      echo "Please enter the codebuild project name"
+      exit 1
+    else
+      project_name="${1}"
+    fi
+    aws codebuild list-builds-for-project \
+      --project-name ${project_name} --query 'ids[0]' --output text |cut -d: -f2
+  }; f
+
+
+codebuild-tail-log =
   !f() {
     if [ "${1}" == "" ]; then
       echo "Please enter the codebuild project name"
@@ -144,13 +157,14 @@ get-codebuild-build-log =
       log_group_name="/aws/codebuild/${1}"
     fi
     if [ "${2}" == "" ]; then
-      echo "Please enter the codebuild build id"
-      exit 1
+      echo "Getting the latest build id for codebuild project name ${1}"
+      log_stream_name=$(aws codebuild-get-latest-id ${1})
+      echo "latest build id/log stream name=${log_stream_name}"
     else
       log_stream_name="${2}"
     fi
     aws logs get-log-events \
       --log-group-name ${log_group_name} \
       --log-stream-name ${log_stream_name} \
-      --output text | cut  -f3- | sed  '/^$/d' | less
+      --output text | cut  -f3- | sed  '/^$/d'
   }; f

--- a/alias
+++ b/alias
@@ -134,3 +134,23 @@ revoke-my-ip-all =
   !f() {
     aws revoke-my-ip ${1} all all
   }; f
+
+get-codebuild-build-log =
+  !f() {
+    if [ "${1}" == "" ]; then
+      echo "Please enter the codebuild project name"
+      exit 1
+    else
+      log_group_name="/aws/codebuild/${1}"
+    fi
+    if [ "${2}" == "" ]; then
+      echo "Please enter the codebuild build id"
+      exit 1
+    else
+      log_stream_name="${2}"
+    fi
+    aws logs get-log-events \
+      --log-group-name ${log_group_name} \
+      --log-stream-name ${log_stream_name} \
+      --output text | cut  -f3- | sed  '/^$/d' | less
+  }; f


### PR DESCRIPTION
…d build

Currently the codebuild build log only shows the last 20 lines. The rest of them are stored in CloudWatchLogs which make it hard to debug.  

This alias helps with download the entire log and search for it locally.