### PR TITLE
switch-role and forget-role aliases

### DIFF
--- a/alias
+++ b/alias
@@ -2,6 +2,11 @@
 
 whoami = sts get-caller-identity
 
+#
+# NOTE: AWS CLI has build-in support for IAM roles so it is not really necessary
+# to build own home-grown solution. See "Using AWS IAM Roles" at
+# http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#cli-aws-help-config-vars 
+#
 # To modify variables in current shell you must define bash functions to call switch-role & forget-role
 # aws-switch-role() {
 #  eval $(aws switch-role $1)

--- a/alias
+++ b/alias
@@ -2,6 +2,27 @@
 
 whoami = sts get-caller-identity
 
+# To modify variables in current shell you must define bash functions to call switch-role & forget-role
+# aws-switch-role() {
+#  eval $(aws switch-role $1)
+# }
+#
+# aws-forget-role() {
+#  eval $(aws forget-role)
+# }
+
+switch-role = 
+  !f() {
+    aws --profile ${AWS_PROFILE:-default} sts assume-role --role-arn ${1} --role-session-name "${USER}@${HOSTNAME}" \
+      --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text | \
+    (read KEY SECRET TOKEN; echo "export AWS_ACCESS_KEY_ID=\"$KEY\"; export AWS_SECRET_ACCESS_KEY=\"$SECRET\"; export AWS_SESSION_TOKEN=\"$TOKEN\"")
+  }; f
+
+forget-role = 
+  !f() {
+    echo "unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN"
+  }; f
+
 create-assume-role =
   !f() {
     aws iam create-role --role-name "${1}" \


### PR DESCRIPTION
Sample usage including bash function defs;

$ aws-switch-role() {
> eval $(aws switch-role $1)
> }
$ aws-forget-role() {
> eval $(aws forget-role)
> }
$ aws whoami
{
    "Account": "123456789012",
    "UserId": "AIDAXXXXXXXXXXXXXXXXX",
    "Arn": "arn:aws:iam::123456789012:user/username"
}
$ aws-switch-role arn:aws:iam::234567890123:role/Administrator
$ aws whoami
{
    "Account": "234567890123",
    "UserId": "AROAYYYYYYYYYYYYYYYYY:user@host.local",
    "Arn": "arn:aws:sts::234567890123:assumed-role/Administrator/user@host.local"
}
$ aws-forget-role
$ aws whoami
{
    "Account": "123456789012",
    "UserId": "AIDAXXXXXXXXXXXXXXXXX",
    "Arn": "arn:aws:iam::123456789012:user/username"
}