### PR TITLE
enable lookup of the route53 dns record for an ALB

### DIFF
--- a/alias
+++ b/alias
@@ -137,7 +137,7 @@ revoke-my-ip-all =
 
 get-elbv2-dnsname =
   !f() {
-    dnsname=$(aws elbv2 describe-load-balancers --names ${1} --query 'LoadBalancers[].DNSName' --output text)
+    dnsname=$(aws elbv2 describe-load-balancers --names "${1:?LoadBalancer name}" --query 'LoadBalancers[].DNSName' --output text)
     zone_id=$(aws route53 list-hosted-zones-by-name --dns-name ${2} --query "HostedZones[?Name=='${2}.'].Id" --output text | cut -d/ -f3)
     echo "Looking up ${1} in Hosted Zone ${2} ($zone_id):"
     aws route53 list-resource-record-sets --hosted-zone-id ${zone_id} --query "ResourceRecordSets[?AliasTarget.DNSName=='${dnsname}.'].Name" --output json | jq -r '.[]'

--- a/alias
+++ b/alias
@@ -134,3 +134,11 @@ revoke-my-ip-all =
   !f() {
     aws revoke-my-ip ${1} all all
   }; f
+
+get-elbv2-dnsname =
+  !f() {
+    dnsname=$(aws elbv2 describe-load-balancers --names ${1} --query 'LoadBalancers[].DNSName' --output text)
+    zone_id=$(aws route53 list-hosted-zones-by-name --dns-name ${2} --query "HostedZones[?Name=='${2}.'].Id" --output text | cut -d/ -f3)
+    echo "Looking up ${1} in Hosted Zone ${2} ($zone_id):"
+    aws route53 list-resource-record-sets --hosted-zone-id ${zone_id} --query "ResourceRecordSets[?AliasTarget.DNSName=='${dnsname}.'].Name" --output json | jq -r '.[]'
+  }; f

--- a/alias
+++ b/alias
@@ -138,7 +138,8 @@ revoke-my-ip-all =
 get-elbv2-dnsname =
   !f() {
     dnsname=$(aws elbv2 describe-load-balancers --names "${1:?LoadBalancer name}" --query 'LoadBalancers[].DNSName' --output text)
-    zone_id=$(aws route53 list-hosted-zones-by-name --dns-name ${2} --query "HostedZones[?Name=='${2}.'].Id" --output text | cut -d/ -f3)
+    zone_id=$(aws route53 list-hosted-zones-by-name --dns-name "${2:?Hosted zone/domain name}" --query "HostedZones[?Name=='${2}.'].Id" --output text)
+    zone_id="${zone_id##*/}"
     echo "Looking up ${1} in Hosted Zone ${2} ($zone_id):"
     aws route53 list-resource-record-sets --hosted-zone-id ${zone_id} --query "ResourceRecordSets[?AliasTarget.DNSName=='${dnsname}.'].Name" --output json | jq -r '.[]'
   }; f

--- a/alias
+++ b/alias
@@ -141,5 +141,5 @@ get-elbv2-dnsname =
     zone_id=$(aws route53 list-hosted-zones-by-name --dns-name "${2:?Hosted zone/domain name}" --query "HostedZones[?Name=='${2}.'].Id" --output text)
     zone_id="${zone_id##*/}"
     echo "Looking up ${1} in Hosted Zone ${2} ($zone_id):"
-    aws route53 list-resource-record-sets --hosted-zone-id ${zone_id} --query "ResourceRecordSets[?AliasTarget.DNSName=='${dnsname}.'].Name" --output json | jq -r '.[]'
+	aws route53 list-resource-record-sets --hosted-zone-id "${zone_id}" --query "ResourceRecordSets[?AliasTarget.DNSName=='${dnsname,,}.'].{LBHosts:Name}" --output text
   }; f


### PR DESCRIPTION
Provides a method for looking up the Alias record for an ALB in
a route53 hosted zone knowing only the ALB name and the hosted
zone name.