### PR TITLE
Fix region alias for bourne shell: [[ -> [

### DIFF
--- a/alias
+++ b/alias
@@ -83,7 +83,7 @@ public-ports = ec2 describe-security-groups \
   }'
 
 # List or set your region
-region = !f() { [[ $# -eq 1 ]] && aws configure set region "$1" || aws configure get region; }; f
+region = !f() { [ $# -eq 1 ] && aws configure set region "$1" || aws configure get region; }; f
 
 find-access-key = !f() {
     clear_to_eol=$(tput el)


### PR DESCRIPTION
AWS CLI use Bourne shell sh as subprocess, which doesn't have builtin [[. Use  [ instead.
